### PR TITLE
Subgraph

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -23,3 +23,10 @@ Produces a graph with edges from graph *g* that do not exist in graph *h*, and v
 
 `compose(g, h)`  
 Merges graphs *g* and *h* by taking the set union of all vertices and edges.
+
+`function inducedsubgraph(g::AbstractGraph, iter)`
+Filter *g* to include only the vertices present in iter which should not have duplicates.
+Returns the subgraph of *g* induced by set(iter) along with the mapping from the old vertex names to the new vertex names.
+
+`inducedsubgraph!(h, g, newvid)`
+Inplace filtering for preallocated output, edge iterable, vertex mapping.

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -20,6 +20,7 @@ module LightGraphs
     # operators
     complement, reverse, reverse!, union, intersect,
     difference, symmetric_difference, compose,
+    inducedsubgraph,
 
     # graph visit
     AbstractGraphVisitor, TrivialGraphVisitor, LogGraphVisitor,

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -109,28 +109,3 @@ degree(g::Graph, v::Int) = indegree(g,v)
 density(g::Graph) = (2*ne(g)) / (nv(g) * (nv(g)-1))
 
 
-@doc "filter g to include only the vertices present in iter which should not have duplicates
-returns the subgraph of g induced by set(iter) along with the mapping from the old vertex names to the new vertex names" ->
-function inducedsubgraph(g::AbstractGraph, iter)
-    n = length(iter)
-    h = Graph(n)
-    newvid = Dict()
-    i=1
-    for v in iter
-        newvid[v] = i
-        i +=1
-    end
-    inducedsubgraph!(h,edges(g),newvid)
-    return h, newvid
-end
-
-@doc "inplace filtering for preallocated output, edge iterable, vertex mapping" ->
-function inducedsubgraph!(h::AbstractGraph, edges, newvid)
-    for edg in edges
-        newsrc = get(newvid, src(edg), 0)
-        newdst = get(newvid, dst(edg), 0)
-        if newsrc > 0 && newdst > 0
-            add_edge!(h, newsrc, newdst)
-        end
-    end
-end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -107,3 +107,30 @@ degree(g::Graph, v::Int) = indegree(g,v)
 #         union(neighbors(g,v), [e.dst for e in g.binclist[v]])
 #     )
 density(g::Graph) = (2*ne(g)) / (nv(g) * (nv(g)-1))
+
+
+@doc "filter g to include only the vertices present in iter which should not have duplicates
+returns the subgraph of g induced by set(iter) along with the mapping from the old vertex names to the new vertex names" ->
+function inducedsubgraph(g::AbstractGraph, iter)
+    n = length(iter)
+    h = Graph(n)
+    newvid = Dict()
+    i=1
+    for v in iter
+        newvid[v] = i
+        i +=1
+    end
+    inducedsubgraph!(h,edges(g),newvid)
+    return h, newvid
+end
+
+@doc "inplace filtering for preallocated output, edge iterable, vertex mapping" ->
+function inducedsubgraph!(h::AbstractGraph, edges, newvid)
+    for edg in edges
+        newsrc = get(newvid, src(edg), 0)
+        newdst = get(newvid, dst(edg), 0)
+        if newsrc > 0 && newdst > 0
+            add_edge!(h, newsrc, newdst)
+        end
+    end
+end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -114,3 +114,29 @@ function compose{T<:AbstractGraph}(g::T, h::T)
     end
     return r
 end
+
+#@doc "filter g to include only the vertices present in iter which should not have duplicates
+#returns the subgraph of g induced by set(iter) along with the mapping from the old vertex names to the new vertex names" ->
+function inducedsubgraph(g::AbstractGraph, iter)
+    n = length(iter)
+    h = Graph(n)
+    newvid = Dict()
+    i=1
+    for v in iter
+        newvid[v] = i
+        i +=1
+    end
+    inducedsubgraph!(h,edges(g),newvid)
+    return h, newvid
+end
+
+#@doc "inplace filtering for preallocated output, edge iterable, vertex mapping" ->
+function inducedsubgraph!(h::AbstractGraph, edges, newvid)
+    for edg in edges
+        newsrc = get(newvid, src(edg), 0)
+        newdst = get(newvid, dst(edg), 0)
+        if newsrc > 0 && newdst > 0
+            add_edge!(h, newsrc, newdst)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,8 @@ tests = [
     "maxadjvisit",
     "centrality/betweenness",
     "centrality/closeness",
-    "centrality/degree"
+    "centrality/degree",
+    "subgraphs"
     ]
 
 


### PR DESCRIPTION
easy to use function `function inducedsubgraph(g::AbstractGraph, iter)` which returns the new graph and the vertex name map as a Dict.

worker function for filtering that does not allocate any temporaries.
`@doc "inplace filtering for preallocated output, edge iterable, vertex mapping" ->
function inducedsubgraph!(h::AbstractGraph, edges, newvid)`